### PR TITLE
Add Keynote version

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,53 +5,58 @@ Batch convert PowerPoint files to PDF using Automator on macOS
 Use [this script](./keynote-convert-ppt-to-pdf.applescript) for Keynote version.
 
 ## News
+
 - **August 30, 2024**: Pull Request Merged
-	- A [PR#6](https://github.com/jeongwhanchoi/convert-ppt-to-pdf/pull/6) updating the convert-ppt-to-pdf.applescript has been merged. This update includes:
-		- Improved compatibility with the new Mac OS.
-		- Use of POSIX file paths to get appropriate new file paths.
-		- Additional logging functionality for easier troubleshooting (commented out by default).
+  - A [PR#6](https://github.com/jeongwhanchoi/convert-ppt-to-pdf/pull/6) updating the convert-ppt-to-pdf.applescript has been merged. This update includes:
+    - Improved compatibility with the new Mac OS.
+    - Use of POSIX file paths to get appropriate new file paths.
+    - Additional logging functionality for easier troubleshooting (commented out by default).
 
 - **August 30, 2024**: README and Script Updated
-	- We have updated both the README and the script in response to the macOS Sonoma compatibility issue (see [Issue#5](https://github.com/jeongwhanchoi/convert-ppt-to-pdf/issues/5)). The changes include:
-		- A new script that addresses the alias handling problem in macOS Sonoma.
+  - We have updated both the README and the script in response to the macOS Sonoma compatibility issue (see [Issue#5](https://github.com/jeongwhanchoi/convert-ppt-to-pdf/issues/5)). The changes include:
+    - A new script that addresses the alias handling problem in macOS Sonoma.
 
 ## How to make the Convert to PDF
 
 1. Launch the Automator
-2. Choose a type as *Quick Action* for your documents
+2. Choose a type as _Quick Action_ for your documents
 3. Find Actions, 'Run AppleScript'
 4. Type the AppleScript
    - Set the input setting
    - Type the script
-5. Save the *Quick Action*
+5. Save the _Quick Action_
 
 ---
 
 ## Creating the Quick Action
 
 ### 1. Launch Automator
+
 Open the Automator application on your Mac.
 
 <img src="img/img-00.png" width="300">
 
 ### 2. Choose Quick Action
+
 When creating a new document, select 'Quick Action' as the type for your workflow.
 
 <img src="img/img-01.png" width="300">
 
 ### 3. Add Run AppleScript Action
+
 In the library, search for and add the 'Run AppleScript' action to your workflow.
 
 <img src="img/img-02.png" width="300">
 
 ### 4. Configure Input Settings
+
 Set the workflow to receive input from 'documents' in 'Finder'.
 
 <img src="img/img-03.png" width="300">
 
 ### 5. Enter AppleScript Code
-Copy and paste the following AppleScript code ([link](https://github.com/jeongwhanchoi/convert-ppt-to-pdf/blob/master/convert-ppt-to-pdf.applescript)) into the 'Run AppleScript' action:
 
+Copy and paste the following AppleScript code ([link](https://github.com/jeongwhanchoi/convert-ppt-to-pdf/blob/master/convert-ppt-to-pdf.applescript)) into the 'Run AppleScript' action:
 
 ```app
 on run {input, parameters}
@@ -102,9 +107,11 @@ end makeNewPath
 ---
 
 ### 6. Save the Quick Action
+
 Give your workflow a name (e.g., "Convert PPT to PDF") and save it.
 
 ## How to Use
+
 1. In Finder, select the PowerPoint files you want to convert.
 2. Right-click to open the context menu.
 3. Navigate to Quick Actions > "Convert PPT to PDF".
@@ -115,3 +122,4 @@ Give your workflow a name (e.g., "Convert PPT to PDF") and save it.
 ## Star History
 
 [![Star History Chart](https://api.star-history.com/svg?repos=jeongwhanchoi/convert-ppt-to-pdf&type=Date)](https://star-history.com/#jeongwhanchoi/convert-ppt-to-pdf&Date)
+

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Batch convert PowerPoint files to PDF using Automator on macOS
 
+Use [this script](./keynote-convert-ppt-to-pdf.applescript) for Keynote version.
+
 ## News
 - **August 30, 2024**: Pull Request Merged
 	- A [PR#6](https://github.com/jeongwhanchoi/convert-ppt-to-pdf/pull/6) updating the convert-ppt-to-pdf.applescript has been merged. This update includes:

--- a/keynote-convert-ppt-to-pdf.applescript
+++ b/keynote-convert-ppt-to-pdf.applescript
@@ -1,0 +1,52 @@
+on run {input, parameters}
+    set theOutput to {}
+
+    tell application "Keynote"
+        launch
+        repeat with i in input
+            set t to i as string
+            if t ends with ".ppt" or t ends with ".pptx" then
+                set pdfPath to my makePDFPath(i)
+                try
+                    -- Open the PPT/PPTX in Keynote
+                    open i
+                    my waitForOpen()
+
+                    -- Export to PDF (Keynote's native export)
+                    export document 1 to (POSIX file pdfPath) as PDF
+
+                    -- Close without saving changes to .key
+                    close document 1 saving no
+
+                    set end of theOutput to pdfPath
+                on error errMsg number errNum
+                    try
+                        if (count of documents) > 0 then close document 1 saving no
+                    end try
+                    -- optional: display dialog ("Export error: " & errMsg)
+                end try
+            end if
+        end repeat
+        quit
+    end tell
+
+    return theOutput
+end run
+
+on makePDFPath(f)
+    set t to f as string
+    if t ends with ".pptx" then
+        return (POSIX path of (text 1 thru -6 of t)) & ".pdf"
+    else
+        return (POSIX path of (text 1 thru -5 of t)) & ".pdf"
+    end if
+end makePDFPath
+
+on waitForOpen()
+    tell application "Keynote"
+        repeat 200 times
+            if (count of documents) > 0 then exit repeat
+            delay 0.1
+        end repeat
+    end tell
+end waitForOpen


### PR DESCRIPTION
## Motivation

This PR adds support for the Keynote version of the conversion script.

**Note:** During testing, I noticed that Keynote-generated PDFs are significantly smaller in file size compared to those exported from PowerPoint.

## Proposed solution

- [x] Update the `README` to mention the Keynote option
- [x] Apply Markdown linter autofix on the `README`
- [x] Introduce a Keynote AppleScript for Automator to convert PPT/PPTX files to PDF via Quick Actions